### PR TITLE
Adjust bottom UI layout

### DIFF
--- a/slotmachine.js
+++ b/slotmachine.js
@@ -642,13 +642,12 @@ function resizeUI(gameSize) {
     balanceText.setOrigin(0, 1);
     settingsButton.setOrigin(settings.rightHand ? 0 : 1, 0);
 
-    spinButton.setPosition(width / 2, bottom);
-    const autoSpacing =
-      spinButton.width / 2 + margin + autoSpinButton.width / 2;
-    const betSpacing = spinButton.width / 2 + margin + betButton.width / 2;
-    autoSpinButton.setPosition(width / 2 - autoSpacing, bottom);
-    betButton.setPosition(width / 2 + betSpacing, bottom);
-    balanceText.setPosition(margin, bottom);
+    const quarter = width / 4;
+    spinButton.setPosition(quarter * 2, bottom);
+    autoSpinButton.setPosition(quarter, bottom);
+    betButton.setPosition(quarter * 3, bottom);
+    const balanceOffset = 80;
+    balanceText.setPosition(margin, bottom - balanceOffset);
     const settingsX = settings.rightHand ? margin : width - margin;
     settingsButton.setPosition(settingsX, margin);
   }

--- a/slotmachine.js
+++ b/slotmachine.js
@@ -626,8 +626,13 @@ function resizeUI(gameSize) {
     balanceText.setOrigin(right ? 1 : 0, 0);
     settingsButton.setOrigin(right ? 0 : 1, 0);
 
+    spinButton.setFontSize(48);
+    autoSpinButton.setFontSize(28);
+    betButton.setFontSize(28);
+    balanceText.setFontSize(28);
+
     const spacing =
-      Math.max(spinButton.height, autoSpinButton.height, betButton.height) / 2 +
+      Math.max(spinButton.height, autoSpinButton.height, betButton.height) +
       margin;
     spinButton.setPosition(uiX, height / 2);
     autoSpinButton.setPosition(uiX, height / 2 - spacing);
@@ -641,6 +646,11 @@ function resizeUI(gameSize) {
     betButton.setOrigin(0.5, 1);
     balanceText.setOrigin(0, 1);
     settingsButton.setOrigin(settings.rightHand ? 0 : 1, 0);
+
+    spinButton.setFontSize(72);
+    autoSpinButton.setFontSize(40);
+    betButton.setFontSize(40);
+    balanceText.setFontSize(40);
 
     const quarter = width / 4;
     spinButton.setPosition(quarter * 2, bottom);


### PR DESCRIPTION
## Summary
- position bottom buttons at equal screen intervals
- move balance display upward

## Testing
- `node --check slotmachine.js`


------
https://chatgpt.com/codex/tasks/task_b_686658abd75483339e406391dfeb649c