### PR TITLE
Swap text spin button for image

### DIFF
--- a/slotmachine.js
+++ b/slotmachine.js
@@ -277,6 +277,7 @@ async function startGame() {
       fontFamily: "Arial",
     })
     .setOrigin(0.5)
+    .setDepth(10)
     .setVisible(false);
   winText.setShadow(0, 0, "#ffff00", 10, true, true);
 
@@ -497,21 +498,25 @@ function update(time, delta) {
   }
   if (!anySpinning) {
     isSpinning = false;
-    // this.game.canvas.style.filter = "";
-    if (spinButton) {
-      spinButton.setAlpha(1);
-      spinButton.setInteractive({ useHandCursor: true });
-    }
+    // update final screen before showing the result
     if (finalScreen) {
       currentScreen = finalScreen.map((row) => [...row]);
       finalScreen = null;
     }
+
+    // show winnings before allowing another spin
     if (lastResult && lastResult.outcome.win > 0) {
       highlightWin.call(this, lastResult.outcome, lastResult.features);
     } else {
       clearWin();
     }
     updateUI();
+
+    if (spinButton) {
+      spinButton.setAlpha(1);
+      spinButton.setInteractive({ useHandCursor: true });
+    }
+
     lastResult = null;
     if (autoSpin) {
       this.time.delayedCall(500, () => {

--- a/slotmachine.js
+++ b/slotmachine.js
@@ -307,14 +307,8 @@ async function startGame() {
     });
 
   spinButton = this.add
-    // .image(0, 0, "spin")
-    // .setScale(0.5)
-    .text(0, 0, "SPIN", {
-      fontSize: "60px",
-      color: "#ffffff",
-      backgroundColor: "#444",
-      padding: { x: 10, y: 5 },
-    })
+    .image(0, 0, "spin")
+    .setScale(0.5)
     .setOrigin(0.5)
     .setInteractive({ useHandCursor: true })
     .on("pointerdown", () => {
@@ -626,13 +620,17 @@ function resizeUI(gameSize) {
     balanceText.setOrigin(right ? 1 : 0, 0);
     settingsButton.setOrigin(right ? 0 : 1, 0);
 
-    spinButton.setFontSize(48);
+    spinButton.setScale(0.5);
     autoSpinButton.setFontSize(28);
     betButton.setFontSize(28);
     balanceText.setFontSize(28);
 
     const spacing =
-      Math.max(spinButton.height, autoSpinButton.height, betButton.height) +
+      Math.max(
+        spinButton.displayHeight,
+        autoSpinButton.displayHeight,
+        betButton.displayHeight,
+      ) +
       margin;
     spinButton.setPosition(uiX, height / 2);
     autoSpinButton.setPosition(uiX, height / 2 - spacing);
@@ -647,7 +645,7 @@ function resizeUI(gameSize) {
     balanceText.setOrigin(0, 1);
     settingsButton.setOrigin(settings.rightHand ? 0 : 1, 0);
 
-    spinButton.setFontSize(72);
+    spinButton.setScale(0.7);
     autoSpinButton.setFontSize(40);
     betButton.setFontSize(40);
     balanceText.setFontSize(40);
@@ -675,10 +673,10 @@ function layoutGame(gameSize) {
     spriteScale = 0.25;
     const uiWidth =
       Math.max(
-        spinButton.width,
-        autoSpinButton.width,
-        betButton.width,
-        balanceText.width,
+        spinButton.displayWidth,
+        autoSpinButton.displayWidth,
+        betButton.displayWidth,
+        balanceText.displayWidth,
       ) +
       margin * 2;
     const availableWidth = width - uiWidth;
@@ -688,7 +686,11 @@ function layoutGame(gameSize) {
   } else {
     spriteScale = 0.3;
     const uiHeight = spinButton
-      ? Math.max(spinButton.height, autoSpinButton.height, betButton.height) +
+      ? Math.max(
+          spinButton.displayHeight,
+          autoSpinButton.displayHeight,
+          betButton.displayHeight,
+        ) +
         margin * 2
       : 80;
     centerY = (height - uiHeight) / 2;


### PR DESCRIPTION
## Summary
- load `spin.png` in Phaser preload
- switch spin button to use the `spin` image instead of text
- adjust UI scaling and layout for image-based button

## Testing
- `node --check slotmachine.js`

------
https://chatgpt.com/codex/tasks/task_b_68666026b700833383e63f60bece553d