### PR TITLE
Use image for spin button

### DIFF
--- a/slotmachine.js
+++ b/slotmachine.js
@@ -307,14 +307,8 @@ async function startGame() {
     });
 
   spinButton = this.add
-    // .image(0, 0, "spin")
-    // .setScale(0.5)
-    .text(0, 0, "SPIN", {
-      fontSize: "60px",
-      color: "#ffffff",
-      backgroundColor: "#444",
-      padding: { x: 10, y: 5 },
-    })
+    .image(0, 0, "spin")
+    .setScale(0.5)
     .setOrigin(0.5)
     .setInteractive({ useHandCursor: true })
     .on("pointerdown", () => {
@@ -626,7 +620,7 @@ function resizeUI(gameSize) {
     balanceText.setOrigin(right ? 1 : 0, 0);
     settingsButton.setOrigin(right ? 0 : 1, 0);
 
-    spinButton.setFontSize(48);
+    spinButton.setScale(0.4);
     autoSpinButton.setFontSize(28);
     betButton.setFontSize(28);
     balanceText.setFontSize(28);
@@ -647,7 +641,7 @@ function resizeUI(gameSize) {
     balanceText.setOrigin(0, 1);
     settingsButton.setOrigin(settings.rightHand ? 0 : 1, 0);
 
-    spinButton.setFontSize(72);
+    spinButton.setScale(0.6);
     autoSpinButton.setFontSize(40);
     betButton.setFontSize(40);
     balanceText.setFontSize(40);


### PR DESCRIPTION
## Summary
- swap text spin button for image in assets
- adjust UI scaling to use scale instead of font size

## Testing
- `pip install pillow` *(to inspect image)*

------
https://chatgpt.com/codex/tasks/task_b_6867826d072c8333a6be46f39bd0f23d