### PR TITLE
Move balance indicator in landscape

### DIFF
--- a/slotmachine.js
+++ b/slotmachine.js
@@ -788,7 +788,8 @@ function resizeUI(gameSize) {
     spinButton.setOrigin(right ? 1 : 0, 0.5);
     autoSpinButton.setOrigin(right ? 1 : 0, 0.5);
     betButton.setOrigin(right ? 1 : 0, 0.5);
-    balanceText.setOrigin(right ? 1 : 0, 0);
+    // Position balance in bottom-left corner for landscape layout
+    balanceText.setOrigin(0, 1);
     settingsButton.setOrigin(right ? 0 : 1, 0);
     infoButton.setOrigin(right ? 1 : 0, 0);
 
@@ -804,7 +805,9 @@ function resizeUI(gameSize) {
     spinButton.setPosition(uiX, height / 2);
     autoSpinButton.setPosition(uiX, height / 2 - spacing);
     betButton.setPosition(uiX, height / 2 + spacing);
-    balanceText.setPosition(uiX, margin);
+    const balanceX = margin;
+    const balanceY = height - margin;
+    balanceText.setPosition(balanceX, balanceY);
     settingsButton.setPosition(settingsX, margin);
     infoButton.setPosition(infoX, margin);
   } else {


### PR DESCRIPTION
## Summary
- position the balance text in the bottom left when in landscape mode

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686ccaf0cde883338e35f76452cbc4c8