### PR TITLE
Fix balance update timing

### DIFF
--- a/slotmachine.js
+++ b/slotmachine.js
@@ -559,6 +559,7 @@ async function spin(result) {
   );
 
   balance = `${result.balance.wallet}`;
+  updateUI();
 
   for (let c = 0; c < cols; c++) {
     const reel = reels[c];


### PR DESCRIPTION
## Summary
- update player balance text as soon as spin results arrive

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870c77b65248333943b8e3e6c1ac00f