### PR TITLE
Replace start button with nine slice

### DIFF
--- a/slotmachine.js
+++ b/slotmachine.js
@@ -1237,8 +1237,6 @@ function openAutoSpinMenu() {
   const style = {
     fontSize: "24px",
     color: "#ffffff",
-    backgroundColor: "#444",
-    padding: { x: 10, y: 5 },
     fontFamily: "Arial",
   };
 
@@ -1256,8 +1254,19 @@ function openAutoSpinMenu() {
       row * (buttonHeight + spacing) +
       buttonHeight / 2;
     const label = `${opt}`;
-    const text = this.add
-      .text(x, y, label, style)
+    const buttonBg = this.add
+      .nineslice(
+        x,
+        y,
+        "settingsPanel",
+        undefined,
+        buttonWidth,
+        buttonHeight,
+        20,
+        20,
+        20,
+        20,
+      )
       .setOrigin(0.5)
       .setInteractive({ useHandCursor: true })
       .on("pointerdown", () => {
@@ -1270,6 +1279,11 @@ function openAutoSpinMenu() {
           startSpin(this);
         }
       });
+    const text = this.add
+      .text(x, y, label, style)
+      .setOrigin(0.5);
+
+    panel.add(buttonBg);
     panel.add(text);
   });
 

--- a/slotmachine.js
+++ b/slotmachine.js
@@ -288,15 +288,33 @@ function createWelcomeScreen() {
     .setScale(0.6)
     .setOrigin(0.5);
 
-  const startButton = this.add
+  const buttonWidth = 220;
+  const buttonHeight = 80;
+  const startBg = this.add
+    .nineslice(
+      width / 2,
+      height - 100,
+      "settingsPanel",
+      undefined,
+      buttonWidth,
+      buttonHeight,
+      20,
+      20,
+      20,
+      20,
+    )
+    .setOrigin(0.5)
+    .setInteractive({ useHandCursor: true });
+
+  const startText = this.add
     .text(width / 2, height - 100, "START", {
       fontSize: "48px",
       color: "#ffffff",
-      backgroundColor: "#444",
-      padding: { x: 10, y: 5 },
+      fontFamily: "Arial",
     })
-    .setOrigin(0.5)
-    .setInteractive({ useHandCursor: true });
+    .setOrigin(0.5);
+
+  const startButton = this.add.container(0, 0, [startBg, startText]);
 
   const symbols = ["helmet", "shoe", "can", "badge"];
   symbols.forEach((key, idx) => {
@@ -308,7 +326,7 @@ function createWelcomeScreen() {
     container.add(sprite);
   });
 
-  startButton.on("pointerdown", () => {
+  startBg.on("pointerdown", () => {
     if (logoImage) {
       logoImage.destroy();
     }

--- a/slotmachine.js
+++ b/slotmachine.js
@@ -1135,8 +1135,6 @@ function openBetMenu() {
   const style = {
     fontSize: "24px",
     color: "#ffffff",
-    backgroundColor: "#444",
-    padding: { x: 10, y: 5 },
     fontFamily: "Arial",
   };
 
@@ -1153,8 +1151,19 @@ function openBetMenu() {
       spacing +
       row * (buttonHeight + spacing) +
       buttonHeight / 2;
-    const text = this.add
-      .text(x, y, `${formatCurrency(bet)}`, style)
+    const buttonBg = this.add
+      .nineslice(
+        x,
+        y,
+        "settingsPanel",
+        undefined,
+        buttonWidth,
+        buttonHeight,
+        20,
+        20,
+        20,
+        20,
+      )
       .setOrigin(0.5)
       .setInteractive({ useHandCursor: true })
       .on("pointerdown", () => {
@@ -1163,7 +1172,13 @@ function openBetMenu() {
         updateUI();
         closeBetMenu.call(this);
       });
-    panel.add(text);
+
+    const buttonText = this.add
+      .text(x, y, `${formatCurrency(bet)}`, style)
+      .setOrigin(0.5);
+
+    panel.add(buttonBg);
+    panel.add(buttonText);
   });
   betMenuContainer.add([bg, panel]);
 }


### PR DESCRIPTION
## Summary
- style the welcome screen's start button using a nine-slice image

## Testing
- `node --check slotmachine.js`

------
https://chatgpt.com/codex/tasks/task_b_68834f0553c48333aaa5e063721799c9